### PR TITLE
chore(dependabot): add 10-day cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: "friday"
       time: "00:30"
     target-branch: "main"
+    cooldown:
+      default-days: 10
     assignees:
       - "hibare"
     groups:
@@ -24,6 +26,8 @@ updates:
       day: "friday"
       time: "00:30"
     target-branch: "main"
+    cooldown:
+      default-days: 10
     assignees:
       - "hibare"
     allow:
@@ -43,6 +47,8 @@ updates:
       day: "friday"
       time: "00:30"
     target-branch: "main"
+    cooldown:
+      default-days: 10
     assignees:
       - "hibare"
     groups:


### PR DESCRIPTION
This PR adds a 10-day default cooldown period to each package manager in the dependabot configuration.

## Why this matters for supply chain security

Rapid automated dependency updates can introduce significant supply chain risks:

1. **Typosquatting attacks**: Attackers publish malicious packages with names similar to popular dependencies. Dependabot's quick updates may automatically adopt these before the community flags them.

2. **Compromised maintainer accounts**: If a popular package maintainer's account is compromised, attackers can push malicious versions. A cooldown period gives time for the community to detect and warn about such attacks.

3. **Dependency confusion**: Attackers exploit naming conflicts between public and private registries. Faster updates mean less time to detect such attacks.

4. **Zero-day vulnerabilities in dependencies**: When new vulnerabilities are disclosed, attackers immediately exploit them. A delay in updating gives time to assess the actual risk and implement mitigations.

5. **Build chain attacks**: Automated updates can introduce changes that break the build or introduce backdoors. A cooldown period allows for better monitoring and testing.

By adding a 10-day cooldown, we reduce the attack surface while still maintaining regular security updates.